### PR TITLE
update `uncipher` to `uncipherfile` in README and a suggestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Attacks :
 
 ## Usage:
 usage: RsaCtfTool.py [-h] \(--publickey PUBLICKEY | --createpub | --dumpkey\)
-                         [--uncipher UNCIPHER] [--verbose] [--private] [--n N]
+                         [--uncipherfile UNCIPHERFILE] [--verbose] [--private] [--n N]
                          [--e E] [--ecmdigits DIGITS] [--key KEY]
 
 Mode 1 - Attack RSA (specify --publickey)
@@ -37,7 +37,7 @@ Mode 3 - Dump the public and/or private numbers from a PEM/DER format public or 
  - key - the public or private key in PEM or DER format
 
 ### Uncipher file :
-`./RsaCtfTool.py --publickey ./key.pub --uncipher ./ciphered\_file`
+`./RsaCtfTool.py --publickey ./key.pub --uncipherfile ./ciphered\_file`
 
 ### Print private key :
 `./RsaCtfTool.py --publickey ./key.pub --private`

--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -26,6 +26,8 @@ import tempfile
 import sys
 
 sys.setrecursionlimit(2000)
+if sys.version_info < (3, 0):
+    int = long
 
 
 class FactorizationError(Exception):
@@ -543,7 +545,7 @@ if __name__ == "__main__":
     parser.add_argument('--createpub', help='Take n and e from cli and just print a public key then exit', action='store_true')
     parser.add_argument('--dumpkey', help='Just dump the RSA variables from a key - n,e,d,p,q', action='store_true')
     parser.add_argument('--uncipherfile', help='uncipher a file', default=None)
-    parser.add_argument('--uncipher', help='uncipher a file', default=None)
+    parser.add_argument('--uncipher', help='uncipher a cipher', default=None)
     parser.add_argument('--verbose', help='verbose mode (display n, e, p and q)', action='store_true')
     parser.add_argument('--private', help='Display private key if recovered', action='store_true')
     parser.add_argument('--ecmdigits', type=int, help='Optionally an estimate as to how long one of the primes is for ECM method', default=None)


### PR DESCRIPTION
In this commit, I write a line. If the python version is below 3.0, it will overwrite `int` by `long` so that python2 is still supported.
It is ugly, but it just a suggestion that you either support python2 in an ugly way or at least you should tell people python2 is no longer supported.