### PR TITLE
Fix for issue #22

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -558,6 +558,9 @@ if __name__ == "__main__":
     parser.add_argument('--attack', help='Specify the attack mode.', default="all", choices=attacks_list)
 
     args = parser.parse_args()
+    if len(sys.argv) == 1:
+        parser.print_help()
+        sys.exit(1)
 
     # Parse longs if exists
     if args.p and args.q is not None:


### PR DESCRIPTION
Error is generated when no command line arguments are provided:
```
File "C:\Python27\RsaCtfTool\RsaCtfTool.py", line 103, in init
if '*' in args.publickey or '?' in args.publickey:
    TypeError: argument of type 'NoneType' is not iterable]
```
This commit checks the length of sys.argv to see if command line arguments have been provided. If not, it prints the help message and exits.