### PR TITLE
Fix py2 to py3 migration problem in siqs function

### DIFF
--- a/siqs.py
+++ b/siqs.py
@@ -73,8 +73,8 @@ class SiqsAttack(object):
                 return
 
             for line in yafurun.splitlines():
-                if re.search('^P[0-9]+\ =\ [0-9]+$', line):
-                    primesfound.append(int(line.split('=')[1]))
+                if re.search(b'^P[0-9]+\ =\ [0-9]+$', line):
+                    primesfound.append(int(line.split(b'=')[1]))
 
             if len(primesfound) == 2:
                 self.p = primesfound[0]


### PR DESCRIPTION
TypeError exception occurred when using siqs attacking method
```
./RsaCtfTool.py --publickey pub.pem --private --attack siqs
```
```
Traceback (most recent call last):
  File "./RsaCtfTool.py", line 725, in <module>
    attackobj.attack()
  File "./RsaCtfTool.py", line 519, in attack
    getattr(self, attack.__name__)()
  File "./RsaCtfTool.py", line 449, in siqs
    siqsobj.doattack()
  File "/usr/home/hyili/python-env/RsaCtfTool/siqs.py", line 78, in doattack
    if re.search('^P[0-9]+\ =\ [0-9]+$', line):
  File "/usr/local/lib/python3.6/re.py", line 182, in search
    return _compile(pattern, flags).search(string)
TypeError: cannot use a string pattern on a bytes-like object
```