### PR TITLE
Restructured commonfactors()

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -410,10 +410,13 @@ class RSAAttack(object):
                     y.priv_key = PrivateKey(int(y.pub_key.p), int(y.pub_key.q),
                                             int(y.pub_key.e), int(y.pub_key.n))
 
-                # call attack method to print the private keys at the nullattack step or attack singularly
-                # depending on the success of the gcd operation
-                x.attack()
-                y.attack()
+                    # call attack method to print the private keys at the nullattack step
+                    x.attack()
+                    y.attack()
+
+        # attack singularly if gcd operation was not successful
+        for ao in self.attackobjs:
+            ao.attack()
 
         return
 


### PR DESCRIPTION
This fixes the following (imho) unwanted behavior:
When starting an attack on multiple public keys, the program performs the gcd attack on a pair of keys and then launches all (specified) singular attacks on each one. 
This can be unnecessarily costly (time wise), especially when performing primefac on each key. 
The better approach (and the approach most users would presumably expect, at least it was not made clear that the program is not done with the gcd approach when launching the first singular attacks) is to first try gcd on every pair before proceeding.

Minor tweak:
Changed testing every permutation to testing every combination, i.e. testing (1, 3) but not (3, 1) for speed up (substantial when launching singular attacks on a huge amount of keys).  