### PR TITLE
Implement Carl Londahl's factorisation for close p and q

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Attacks :
  - Elliptic Curve Method
  - Pollards p-1 for relatively smooth numbers
  - Mersenne primes factorization
+ - Londahl's factorisation for close p and q
 
 ## Usage:
 
@@ -33,7 +34,7 @@ usage: RsaCtfTool.py [-h] [--publickey PUBLICKEY] [--createpub] [--dumpkey] [--e
                      [--uncipherfile UNCIPHERFILE] [--uncipher UNCIPHER]
                      [--verbose] [--private] [--ecmdigits ECMDIGITS] [-n N]
                      [-p P] [-q Q] [-e E] [--key KEY]
-                     [--attack {hastads,factordb,pastctfprimes,mersenne_primes,noveltyprimes,smallq,wiener,comfact_cn,primefac,fermat,siqs,Pollard_p_1,all}]
+                     [--attack {hastads,factordb,pastctfprimes,mersenne_primes,noveltyprimes,smallq,wiener,comfact_cn,primefac,fermat,siqs,Pollard_p_1,londahl,all}]
 ```
 
 Mode 1 - Attack RSA (specify --publickey)

--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -384,6 +384,23 @@ class RSAAttack(object):
 
         return
 
+    def londahl(self, londahl_b=20000000):
+        # Another attack for primes that are too close together.
+        # https://grocid.net/2017/09/16/finding-close-prime-factorizations/
+        # `b` is the size of the lookup dictionary to build.
+        try:
+            import londahl
+        except ImportError:
+            print("[!] Warning: Londahl factorization module missing (londahl.py)")
+            return
+
+        self.pub_key.p, self.pub_key.q = londahl.close_factor(self.pub_key.n, londahl_b)
+
+        if self.pub_key.q is not None:
+            self.priv_key = PrivateKey(int(self.pub_key.p), int(self.pub_key.q),
+                                       int(self.pub_key.e), int(self.pub_key.n))
+
+        return
     def noveltyprimes(self):
         # "primes" of the form 31337 - 313333337 - see ekoparty 2015 "rsa 2070"
         # not all numbers in this form are prime but some are (25 digit is prime)
@@ -593,7 +610,8 @@ class RSAAttack(object):
 
     implemented_attacks = [nullattack, hastads, factordb, pastctfprimes,
                            mersenne_primes, noveltyprimes, smallq, wiener,
-                           comfact_cn, primefac, fermat, siqs, Pollard_p_1]
+                           comfact_cn, primefac, fermat, siqs, Pollard_p_1,
+                           londahl]
 
 
 # source http://stackoverflow.com/a/22348885

--- a/londahl.py
+++ b/londahl.py
@@ -1,0 +1,32 @@
+import gmpy2
+
+def close_factor(n, b):
+ 
+    # approximate phi
+    phi_approx = n - 2 * gmpy2.isqrt(n) + 1
+ 
+    # create a look-up table
+    look_up = {}
+    z = 1
+    for i in range(0, b + 1):
+        look_up[z] = i
+        z = (z * 2) % n
+ 
+    # check the table
+    mu = gmpy2.invert(pow(2, phi_approx, n), n)
+    fac = pow(2, b, n)
+
+    for i in range(0, b + 1):
+        if mu in look_up:
+            phi = phi_approx + (look_up[mu] - i * b)
+            break
+        mu = (mu * fac) % n
+    else:
+        return None
+ 
+    m = n - phi + 1
+    roots = (m - gmpy2.isqrt(m ** 2 - 4 * n)) // 2, \
+            (m + gmpy2.isqrt(m ** 2 - 4 * n)) // 2
+ 
+    assert roots[0] * roots[1] == n
+    return roots


### PR DESCRIPTION
More details on the algorithm can be found here:
https://grocid.net/2017/09/16/finding-close-prime-factorizations/

This PR fixes issue #59.

We first build a lookup table with `b` entries and then calculate `b` entries
to see if they are in the lookup table. This finds factors if our guess for phi
is at most b^2 away from the actual phi, which gives better results than the
Fermat algorithm.  Increasing b increases memory usage and computation time and
finds primes that are less close to each other. Setting a timeout on this
function is a bad idea, since it will build the lookup table and then abort
while it is using the table.