### PR TITLE
Use gmpy2 isqrt for faster Fermat attack

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -363,7 +363,7 @@ class RSAAttack(object):
             return
         return
 
-    def fermat(self, fermat_timeout=60):
+    def fermat(self, fermat_timeout=10):
         # Try an attack where the primes are too close together from BKPCTF2016 - sourcekris
         # this attack module can be optional
         try:

--- a/fermat.py
+++ b/fermat.py
@@ -1,12 +1,5 @@
 # Source - http://stackoverflow.com/a/20465181
-def isqrt(n):
-    x = n
-    y = (x + n // x) // 2
-    while y < x:
-        x = y
-        y = (x + n // x) // 2
-    return x
-
+from gmpy2 import isqrt
 
 def fermat(n):
     a = isqrt(n)


### PR DESCRIPTION
Use gmpy2 isqrt (integer square root) method to speed up the Fermat attack.

    $ time ./RsaCtfTool.py --private --verbose -n 25972291333262886126754531447862342318008651545978317992560097655295088183446179998914931077444319512148686227991189070757443095678470077249876125494379543556802873183692990942814980501685535809333479941435337152229473266539872910509228019837179626153738723064214837836127706995237283519368099181137490083783 -e 65537 --attack fermat

Goes from 0m11.640s to 0m0.251s.

Also, reduce the timeout now that we have a much faster attack. Reduce from 60s
to 10s, which makes the attack faster and still allows it to do more
iterations.

Gmpy2 is one of the requirements and RsaCtfTool.py itself also imports it, so
we can assume it is available. This makes the fermat function return mpz, which
is gmpy2 version of int, but apparently similar enough that it works.