### PR TITLE
Improve smallfraction attack

### DIFF
--- a/smallfraction.sage
+++ b/smallfraction.sage
@@ -1,28 +1,26 @@
 #!/usr/bin/env sage
 
-# reference https://github.com/comaeio/OPCDE/blob/master/15%20ways%20to%20break%20RSA%20security%20-%20Renaud%20Lifchitz/opcde2017-ds-lifchitz-break_rsa.pdf
+# reference https://github.com/comaeio/OPCDE/blob/master/2017/15%20ways%20to%20break%20RSA%20security%20-%20Renaud%20Lifchitz/opcde2017-ds-lifchitz-break_rsa.pdf
 
 import sys
 
 
 def factor(n):
     depth = 50
-    t = len(bin(n).replace("0b", ""))
     nn = RealField(2000)(n)
-    p = 0
-
     x = PolynomialRing(Zmod(n), "x").gen()
 
-    for den in xrange(2, depth + 1):
-        for num in xrange(1, den):
+    for den in IntegerRange(2, depth + 1):
+        for num in IntegerRange(1, den):
             if gcd(num, den) == 1:
-                r = Integer(den) / Integer(num)
-                phint = int(sqrt(nn * r))
+                r = den / num
+                phint = isqrt(nn * r)
                 f = x - phint
                 sr = f.small_roots(beta=0.5)
 
                 if len(sr) > 0:
-                    p = int(phint - sr[0])
+                    p = phint - sr[0]
+                    p = p.lift()
                     if n % p == 0:
                         return p
 
@@ -36,4 +34,3 @@ try:
         print(p)
 except:
     print(0)
-    pass

--- a/smallfraction.sage
+++ b/smallfraction.sage
@@ -4,15 +4,15 @@
 
 import sys
 
-n = int(sys.argv[1])
-depth = 50
-t = len(bin(n).replace("0b", ""))
-nn = RealField(2000)(n)
-p = 0
 
-x = PolynomialRing(Zmod(n), "x").gen()
+def factor(n):
+    depth = 50
+    t = len(bin(n).replace("0b", ""))
+    nn = RealField(2000)(n)
+    p = 0
 
-try:
+    x = PolynomialRing(Zmod(n), "x").gen()
+
     for den in xrange(2, depth + 1):
         for num in xrange(1, den):
             if gcd(num, den) == 1:
@@ -24,9 +24,15 @@ try:
                 if len(sr) > 0:
                     p = int(phint - sr[0])
                     if n % p == 0:
-                        print(p)
-                        break
-    if p == 0:
+                        return p
+
+
+try:
+    n = int(sys.argv[1])
+    p = factor(n)
+    if p is None:
+        print(0)
+    else:
         print(p)
 except:
     print(0)

--- a/smallfraction.sage
+++ b/smallfraction.sage
@@ -7,14 +7,13 @@ import sys
 
 def factor(n):
     depth = 50
-    nn = RealField(2000)(n)
     x = PolynomialRing(Zmod(n), "x").gen()
 
     for den in IntegerRange(2, depth + 1):
         for num in IntegerRange(1, den):
             if gcd(num, den) == 1:
                 r = den / num
-                phint = isqrt(nn * r)
+                phint = isqrt(n * r)
                 f = x - phint
                 sr = f.small_roots(beta=0.5)
 

--- a/smallfraction.sage
+++ b/smallfraction.sage
@@ -5,27 +5,27 @@
 import sys
 
 n = int(sys.argv[1])
-depth=50
-t=len(bin(n).replace('0b',''))
+depth = 50
+t = len(bin(n).replace("0b", ""))
 nn = RealField(2000)(n)
 p = 0
 
-x = PolynomialRing(Zmod(n),"x").gen()
+x = PolynomialRing(Zmod(n), "x").gen()
 
 try:
-    for den in xrange(2,depth+1):
-      for num in xrange(1,den):
-        if gcd(num,den)==1:
-          r=Integer(den)/Integer(num);
-          phint = int(sqrt(nn*r))
-          f = x - phint
-          sr = f.small_roots(beta=0.5)
+    for den in xrange(2, depth + 1):
+        for num in xrange(1, den):
+            if gcd(num, den) == 1:
+                r = Integer(den) / Integer(num)
+                phint = int(sqrt(nn * r))
+                f = x - phint
+                sr = f.small_roots(beta=0.5)
 
-          if len(sr)>0:
-            p = int(phint - sr[0])
-            if n%p==0:
-              print(p)
-              break
+                if len(sr) > 0:
+                    p = int(phint - sr[0])
+                    if n % p == 0:
+                        print(p)
+                        break
     if p == 0:
         print(p)
 except:


### PR DESCRIPTION
Especially, break off the attack once a factor is found. The `break` in the original version only stops the inner loop (num), not the outer loop (den), so
this script would continue searching for a factor.
