### PR TITLE
Handle prime N more gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ RSA tool for ctf - uncipher data from weak public key and try to recover private
 Automatic selection of best attack for the given public key
 
 Attacks :
+ - Prime N detection
  - Weak public key factorization
  - Wiener's attack
  - Hastad's attack (Small public exponent attack)
@@ -34,7 +35,7 @@ usage: RsaCtfTool.py [-h] [--publickey PUBLICKEY] [--createpub] [--dumpkey] [--e
                      [--uncipherfile UNCIPHERFILE] [--uncipher UNCIPHER]
                      [--verbose] [--private] [--ecmdigits ECMDIGITS] [-n N]
                      [-p P] [-q Q] [-e E] [--key KEY]
-                     [--attack {hastads,factordb,pastctfprimes,mersenne_primes,noveltyprimes,smallq,wiener,comfact_cn,primefac,fermat,siqs,Pollard_p_1,londahl,all}]
+                     [--attack {hastads,factordb,pastctfprimes,mersenne_primes,noveltyprimes,smallq,wiener,comfact_cn,primefac,fermat,siqs,Pollard_p_1,londahl,prime_n,all}]
 ```
 
 Mode 1 - Attack RSA (specify --publickey)

--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -110,6 +110,26 @@ class PrivateKey(object):
         return self.key.exportKey().decode("utf-8")
 
 
+class Qone(int):
+    """Represents a value of 1 for prime q, and if you try to calculate phi(q)
+    by doing q-1 it gives the correct result of 1."""
+    def __sub__(a, b):
+        assert a == 1
+        assert b == 1
+        return 1
+
+
+class PrimeKey(PrivateKey):
+    """A private key for when n is prime."""
+    def __init__(self, n, e):
+        assert gmpy2.is_prime(n)
+        phi = n - 1
+        d = invmod(e, phi)
+        p = n
+        q = Qone(1)
+        self.key = RSA.RSAImplementation(use_fast_math=False).construct((n, e, d, p, q))
+
+
 class RSAAttack(object):
     def __init__(self, args):
         if '*' in args.publickey or '?' in args.publickey:
@@ -139,7 +159,6 @@ class RSAAttack(object):
             self.pubkeyfile = args.publickey
             self.pub_key = PublicKey(key)
             self.priv_key = None
-            self.partitial_priv_key = None
             self.displayed = False   # have we already spammed the user with this private key?
             self.args = args
             self.unciphered = None
@@ -220,25 +239,10 @@ class RSAAttack(object):
             r = s.get(url_1 % self.pub_key.n, verify=False)
             regex = re.compile("index\.php\?id\=([0-9]+)", re.IGNORECASE)
             ids = regex.findall(r.text)
-            # check if only 1 factor is returned
-            if len(ids) == 2:
-                # theres a chance that the only factor returned is prime, and so we can derive the priv key from it
-                regex = re.compile("<td>P<\/td>")
-                prime = regex.findall(r.text)
-                if len(prime) == 1:
-                    # n is prime, so lets get the key from it
-                    d = invmod(self.pub_key.e, self.pub_key.n - 1)
-                    # construct key using only n and d
-                    try:
-                        # pycrypto >=2.5
-                        impl = RSA.RSAImplementation(use_fast_math=False)
-                        self.partitial_priv_key = impl.construct((self.pub_key.n, 0))
-                        self.partitial_priv_key.key.d = d
-                    except TypeError:
-                        # pycrypto <=2.4.1
-                        self.partitial_priv_key = RSA.construct((self.pub_key.n, 0, d))
 
-                    return
+            if len(ids) < 3:
+                # Factordb does not have at least two factors
+                return
 
             p_id = ids[1]
             q_id = ids[2]
@@ -257,6 +261,12 @@ class RSAAttack(object):
             return
         except Exception as e:
             return
+
+
+    def prime_n(self):
+        if gmpy2.is_prime(self.pub_key.n):
+            self.priv_key = PrimeKey(self.pub_key.n, self.pub_key.e)
+
 
     def wiener(self):
         # this attack module can be optional based on sympy and wiener_attack.py existing
@@ -575,14 +585,9 @@ class RSAAttack(object):
                     getattr(self, attack.__name__)()
 
                 # check and print resulting private key
-                if self.priv_key is not None or self.partitial_priv_key is not None:
+                if self.priv_key is not None:
                     if self.args.private and not self.displayed:
-                        if self.priv_key is not None:
-                            print(self.priv_key)
-                        else:
-                            print("d: %i" % self.partitial_priv_key.key.d)
-                            print("e: %i" % self.partitial_priv_key.key.e)
-                            print("n: %i" % self.partitial_priv_key.key.n)
+                        print(self.priv_key)
                         self.displayed = True
 
                     break
@@ -594,22 +599,16 @@ class RSAAttack(object):
             if self.cipher and self.priv_key is not None:
                     self.unciphered = self.priv_key.decrypt(self.cipher)
                     print("[+] Clear text : %s" % str(self.unciphered))
-            elif self.cipher and self.partitial_priv_key is not None:
-                    # needed, if n is prime and so we cant calc p and q
-                    enc_msg = bytes_to_long(self.cipher)
-                    dec_msg = self.partitial_priv_key.key._decrypt(enc_msg)
-                    self.unciphered = long_to_bytes(dec_msg)
-                    print("[+] Clear text : %s" % str(self.unciphered))
             elif self.unciphered is not None:
                     print("[+] Clear text : %s" % str(self.unciphered))
             else:
                 if self.cipher is not None and self.args.attack is None:
                     print("[-] Sorry, cracking failed")
 
-            if self.priv_key is None and self.partitial_priv_key is None and self.args.private:
+            if self.priv_key is None and self.args.private:
                 print("[-] Sorry, cracking failed")
 
-    implemented_attacks = [nullattack, hastads, factordb, pastctfprimes,
+    implemented_attacks = [nullattack, hastads, prime_n, factordb, pastctfprimes,
                            mersenne_primes, noveltyprimes, smallq, wiener,
                            comfact_cn, primefac, fermat, siqs, Pollard_p_1,
                            londahl]


### PR DESCRIPTION
In case the modulus N is prime we effectively have one-factor RSA and there is
no security, since phi = n - 1. The tool already handled this case, but this
commit changes the following:

* Separate prime N detection from factordb. Use gmpy2.is_prime to detect
  whether N is prime. This makes it possible to run this attack separately and
  makes factordb simpler.
* Do our best to create a valid RSA private key. This remains a bit of a hack
  since we try to put a single factor into a two-factor key. However, this can
  now output a private key that works with OpenSSL.
* Make outputting the key simpler. We used to have either priv_key or
  partitial_priv_key, but now we just have one, reducing the complexity in the
  output logic.