### PR TITLE
bug fix for when p is equal to q

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -70,7 +70,10 @@ class PrivateKey(object):
            :param n: n from public key
         """
 
-        t = (p-1)*(q-1)
+        if p != q:
+            t = (p-1)*(q-1)
+        else:
+            t = p*(q-1)
         d = invmod(e, t)
         self.key = RSA.construct((n, e, d, p, q))
 


### PR DESCRIPTION
Recently I was playing a ctf where n was a square number. I've used your tool many times, as it's easy to go with. So I thought I was giving bad input to the tool, and wasted some time. Later only, I realized that the n provided in the ctf challenge was a square number and your tool doesn't take into account when p=q, thus giving me wrong unciphered text.