### PR TITLE
Print 0 when QiCheng fails

### DIFF
--- a/qicheng.sage
+++ b/qicheng.sage
@@ -34,4 +34,8 @@ def factor(n):
 
 
 if __name__ == "__main__":
-    print(factor(Integer(sys.argv[1])))
+    p = factor(Integer(sys.argv[1]))
+    if p is None:
+        print(0)
+    else:
+        print(p)


### PR DESCRIPTION
So that we don't get a ValueError when we try to parse the sage output as an
integer in the Python script.