### PR TITLE
Replace long() with int() for Python 3

### DIFF
--- a/partial_q.py
+++ b/partial_q.py
@@ -3,11 +3,6 @@
 from subprocess import check_output
 import libnum
 
-try:
-    long
-except NameError:  # Python 3
-    long = int
-
 # Source:
 # https://0day.work/0ctf-2016-quals-writeups/
 
@@ -90,7 +85,7 @@ if __name__ == "__main__":
     # import the private key manually
     keyfile = 'examples/masked.pem'
     keycmd = ['openssl', 'asn1parse', '-in', keyfile]
-    private_key = [long(x.split(':')[3], 16) for x in check_output(keycmd).splitlines() if 'INTEGER' in x]
+    private_key = [int(x.split(':')[3], 16) for x in check_output(keycmd).splitlines() if 'INTEGER' in x]
 
     # dq from examples/masked.pem
     dp = private_key[4]

--- a/partial_q.py
+++ b/partial_q.py
@@ -3,6 +3,11 @@
 from subprocess import check_output
 import libnum
 
+try:
+    long
+except NameError:  # Python 3
+    long = int
+
 # Source:
 # https://0day.work/0ctf-2016-quals-writeups/
 


### PR DESCRIPTION
__long__ was removed in Python 3 because all __int__ are of infinite precision.  Discovered via #77