### PR TITLE
Python2 is default in MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ pip install -r "requirements.txt"
 ```
 
 ### MacOS-specific Instructions
-If `pip install -r "requirements.txt"` fails to install requirements accessible within environment, the following command may work.
+If `pip3 install -r "requirements.txt"` fails to install requirements accessible within environment, the following command may work.
 
 `` easy_install `cat requirements.txt` ``
 


### PR DESCRIPTION
Changing pip to pip3 for installing requirements.txt