### PR TITLE
Added six to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ PyCrypto
 GMPY2
 SymPy
 requests
+six


### PR DESCRIPTION
Added PyPi package six to requirements.txt, as it is required by primefac.

This PR fixes issue #86 