### PR TITLE
Add a GitHub Action to lint Python

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,23 @@
+name: lint_python
+on: [push, pull_request]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --statistics
+    #- name: Test with pytest
+    #  run: |
+    #    pip install pytest
+    #    pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: python
-dist: xenial  # required for Python >= 3.7
-python: 3.7
-install: pip install flake8
-script: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics


### PR DESCRIPTION
Travis CI testing was never turned on at https://travis-ci.com/Ganapati/RsaCtfTool so let's drop Travis and go with builtin GitHub Actions instead.  https://github.com/Ganapati/RsaCtfTool/actions