### PR TITLE
requirements.txt: GMPY2>=2.1.0b4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyCrypto
-GMPY2>=2.1.0b4
+GMPY2; sys_platform == 'darwin'  # Fails on Linux and Windows
 SymPy
 requests
 six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 PyCrypto
-GMPY2
+GMPY2>=2.1.0b4
 SymPy
 requests
 six


### PR DESCRIPTION
`pip install gmpy2` fails on Linux and Windows...  See: aleaxit/gmpy#270 

See https://gmpy2.readthedocs.io/en/latest/intro.html#installation for installation on Linux and Windows 