### PR TITLE
added a valid requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ GMPY2
 SymPy
 requests
 six
+cryptography


### PR DESCRIPTION
"cryptography" is needed, without it RsaCtfTool can't be executed.
This error message has been shown in Manjaro Linux Distribution. So I think this merge will save a lot of time for many users. :smile: 

```bash
Traceback (most recent call last):
  File "RsaCtfTool.py", line 21, in <module>
    from lib.rsa_attack import RSAAttack
  File "/home/shaswata56/Downloads/challenge/RsaCtfTool/lib/rsa_attack.py", line 7, in <module>
    from lib.keys_wrapper import PublicKey
  File "/home/shaswata56/Downloads/challenge/RsaCtfTool/lib/keys_wrapper.py", line 10, in <module>
    from cryptography.hazmat.primitives import serialization
ModuleNotFoundError: No module named 'cryptography'
```