### PR TITLE
added path to track root directory of the tool

### DIFF
--- a/attacks/single_key/boneh_durfee.py
+++ b/attacks/single_key/boneh_durfee.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 from Crypto.PublicKey import RSA
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -16,11 +17,9 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
        many of these problems will be solved by the wiener attack module but perhaps some will fall through to here
     """
     try:
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        sagepath = os.path.join(dir_path, "../../sage/boneh_durfee.sage")
         sageresult = int(
             subprocess.check_output(
-                ["sage", sagepath, str(publickey.n), str(publickey.e)],
+                ["sage", "%s/sage/boneh_durfee.sage" % root, str(publickey.n), str(publickey.e)],
                 timeout=attack_rsa_obj.args.timeout,
             )
         )

--- a/attacks/single_key/boneh_durfee.py
+++ b/attacks/single_key/boneh_durfee.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from Crypto.PublicKey import RSA
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/boneh_durfee.py
+++ b/attacks/single_key/boneh_durfee.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from Crypto.PublicKey import RSA
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -19,7 +19,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = int(
             subprocess.check_output(
-                ["sage", "%s/sage/boneh_durfee.sage" % root, str(publickey.n), str(publickey.e)],
+                ["sage", "%s/sage/boneh_durfee.sage" % rootpath, str(publickey.n), str(publickey.e)],
                 timeout=attack_rsa_obj.args.timeout,
             )
         )

--- a/attacks/single_key/ecm.py
+++ b/attacks/single_key/ecm.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -28,14 +28,14 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
             if ecmdigits:
                 sageresult = int(
                     subprocess.check_output(
-                        ["sage", "%s/sage/ecm.sage" % root, str(publickey.n), str(ecmdigits)],
+                        ["sage", "%s/sage/ecm.sage" % rootpath, str(publickey.n), str(ecmdigits)],
                         timeout=attack_rsa_obj.args.timeout,
                     )
                 )
             else:
                 sageresult = int(
                     subprocess.check_output(
-                        ["sage", "%s/sage/ecm.sage" % root, str(publickey.n)],
+                        ["sage", "%s/sage/ecm.sage" % rootpath, str(publickey.n)],
                         timeout=attack_rsa_obj.args.timeout,
                     )
                 )

--- a/attacks/single_key/ecm.py
+++ b/attacks/single_key/ecm.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -24,19 +25,17 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         try:
             ecmdigits = attack_rsa_obj.args.ecmdigits
-            dir_path = os.path.dirname(os.path.realpath(__file__))
-            sagepath = os.path.join(dir_path, "../../sage/ecm.sage")
             if ecmdigits:
                 sageresult = int(
                     subprocess.check_output(
-                        ["sage", sagepath, str(publickey.n), str(ecmdigits)],
+                        ["sage", "%s/sage/ecm.sage" % root, str(publickey.n), str(ecmdigits)],
                         timeout=attack_rsa_obj.args.timeout,
                     )
                 )
             else:
                 sageresult = int(
                     subprocess.check_output(
-                        ["sage", sagepath, str(publickey.n)],
+                        ["sage", "%s/sage/ecm.sage" % root, str(publickey.n)],
                         timeout=attack_rsa_obj.args.timeout,
                     )
                 )

--- a/attacks/single_key/ecm.py
+++ b/attacks/single_key/ecm.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/ecm2.py
+++ b/attacks/single_key/ecm2.py
@@ -7,7 +7,7 @@ import subprocess
 from lib.rsalibnum import modInv
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/ecm2.py
+++ b/attacks/single_key/ecm2.py
@@ -7,7 +7,7 @@ import subprocess
 from lib.rsalibnum import modInv
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -27,7 +27,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
         sageresult = []
         try:
             sageresult = subprocess.check_output(
-                ["sage", "%s/sage/ecm2.sage" % root, str(publickey.n)],
+                ["sage", "%s/sage/ecm2.sage" % rootpath, str(publickey.n)],
                 timeout=attack_rsa_obj.args.timeout,
             )
             sageresult = sageresult[1:-2].split(b", ")

--- a/attacks/single_key/ecm2.py
+++ b/attacks/single_key/ecm2.py
@@ -7,6 +7,7 @@ import subprocess
 from lib.rsalibnum import modInv
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -25,10 +26,8 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = []
         try:
-            dir_path = os.path.dirname(os.path.realpath(__file__))
-            sagepath = os.path.join(dir_path, "../../sage/ecm2.sage")
             sageresult = subprocess.check_output(
-                ["sage", sagepath, str(publickey.n)],
+                ["sage", "%s/sage/ecm2.sage" % root, str(publickey.n)],
                 timeout=attack_rsa_obj.args.timeout,
             )
             sageresult = sageresult[1:-2].split(b", ")

--- a/attacks/single_key/qicheng.py
+++ b/attacks/single_key/qicheng.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -19,7 +19,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = int(
             subprocess.check_output(
-                ["sage", "%s/sage/qicheng.sage" % root, str(publickey.n)],
+                ["sage", "%s/sage/qicheng.sage" % rootpath, str(publickey.n)],
                 timeout=attack_rsa_obj.args.timeout,
             )
         )

--- a/attacks/single_key/qicheng.py
+++ b/attacks/single_key/qicheng.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/qicheng.py
+++ b/attacks/single_key/qicheng.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -18,7 +19,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = int(
             subprocess.check_output(
-                ["sage", "./sage/qicheng.sage", str(publickey.n)],
+                ["sage", "%s/sage/qicheng.sage" % root, str(publickey.n)],
                 timeout=attack_rsa_obj.args.timeout,
             )
         )

--- a/attacks/single_key/roca.py
+++ b/attacks/single_key/roca.py
@@ -6,6 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -15,7 +16,7 @@ logger = logging.getLogger("global_logger")
 def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = subprocess.check_output(
-            ["sage", "./sage/roca_attack.py", str(publickey.n)],
+            ["sage", "%s/sage/roca_attack.py" %root, str(publickey.n)],
             timeout=attack_rsa_obj.args.timeout,
         )
 

--- a/attacks/single_key/roca.py
+++ b/attacks/single_key/roca.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/roca.py
+++ b/attacks/single_key/roca.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 from lib.timeout import timeout
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -16,7 +16,7 @@ logger = logging.getLogger("global_logger")
 def attack(attack_rsa_obj, publickey, cipher=[]):
     try:
         sageresult = subprocess.check_output(
-            ["sage", "%s/sage/roca_attack.py" %root, str(publickey.n)],
+            ["sage", "%s/sage/roca_attack.py" %rootpath, str(publickey.n)],
             timeout=attack_rsa_obj.args.timeout,
         )
 

--- a/attacks/single_key/smallfraction.py
+++ b/attacks/single_key/smallfraction.py
@@ -5,6 +5,7 @@ import os
 import logging
 import subprocess
 from lib.keys_wrapper import PrivateKey
+from path import root
 
 __SAGE__ = True
 
@@ -14,10 +15,8 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
         only works if the sageworks() function returned True
     """
     try:
-        dir_path = os.path.dirname(os.path.realpath(__file__))
-        sagepath = os.path.join(dir_path, "../../sage/smallfraction.sage")
         r = subprocess.check_output(
-            ["sage", sagepath, str(publickey.n)], timeout=attack_rsa_obj.args.timeout,
+            ["sage", "%s/sage/smallfraction.sage" % root, str(publickey.n)], timeout=attack_rsa_obj.args.timeout,
         )
         sageresult = int(r)
         if sageresult > 0:

--- a/attacks/single_key/smallfraction.py
+++ b/attacks/single_key/smallfraction.py
@@ -5,7 +5,7 @@ import os
 import logging
 import subprocess
 from lib.keys_wrapper import PrivateKey
-from path import root
+from lib.utils import root
 
 __SAGE__ = True
 

--- a/attacks/single_key/smallfraction.py
+++ b/attacks/single_key/smallfraction.py
@@ -5,7 +5,7 @@ import os
 import logging
 import subprocess
 from lib.keys_wrapper import PrivateKey
-from lib.utils import root
+from lib.utils import rootpath
 
 __SAGE__ = True
 
@@ -16,7 +16,7 @@ def attack(attack_rsa_obj, publickey, cipher=[]):
     """
     try:
         r = subprocess.check_output(
-            ["sage", "%s/sage/smallfraction.sage" % root, str(publickey.n)], timeout=attack_rsa_obj.args.timeout,
+            ["sage", "%s/sage/smallfraction.sage" % rootpath, str(publickey.n)], timeout=attack_rsa_obj.args.timeout,
         )
         sageresult = int(r)
         if sageresult > 0:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -10,8 +10,8 @@ from lib.keys_wrapper import PublicKey
 # used to track the location of RsaCtfTool
 # allows sage scripts to be launched anywhere in the fs
 _libutil_ = os.path.realpath(__file__)
-root, _libutil_ = os.path.split(_libutil_)
-root = "%s/.." % root #up one dir
+rootpath, _libutil_ = os.path.split(_libutil_)
+rootpath = "%s/.." % rootpath #up one dir
 
 def get_numeric_value(value):
     """Parse input (hex or numerical)

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,11 +1,17 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
 import logging
 import subprocess
 from lib.rsalibnum import invmod
 from lib.keys_wrapper import PublicKey
 
+# used to track the location of RsaCtfTool
+# allows sage scripts to be launched anywhere in the fs
+_libutil_ = os.path.realpath(__file__)
+root, _libutil_ = os.path.split(_libutil_)
+root = "%s/.." % root #up one dir
 
 def get_numeric_value(value):
     """Parse input (hex or numerical)

--- a/path.py
+++ b/path.py
@@ -1,0 +1,6 @@
+# this file to track the installed root directory of the tool
+# so that the sage attacks can be used anywhere
+import os
+
+full_path = os.path.realpath(__file__)
+root, _this_ = os.path.split(full_path)

--- a/path.py
+++ b/path.py
@@ -1,6 +1,0 @@
-# this file to track the installed root directory of the tool
-# so that the sage attacks can be used anywhere
-import os
-
-full_path = os.path.realpath(__file__)
-root, _this_ = os.path.split(full_path)


### PR DESCRIPTION
after setting up PATH and wanting to use the tool from elsewhere, sage attacks failed due subprocess launching it from '.'
Added a variable to track where the tool is and thus allowing it to be used anywhere.