### PR TITLE
commonfactors.py: Execution time O(2n) instead of O(n**2)

### DIFF
--- a/attacks/multi_keys/commonfactors.py
+++ b/attacks/multi_keys/commonfactors.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import logging
-import itertools
 from lib.rsalibnum import gcd
 from lib.keys_wrapper import PrivateKey
 

--- a/attacks/multi_keys/commonfactors.py
+++ b/attacks/multi_keys/commonfactors.py
@@ -22,7 +22,7 @@ def attack(attack_rsa_obj, publickeys, cipher=[]):
         tmp *= x.n
     for x in publickeys:
         g = gcd(x.n, tmp)
-        if 1<g<n:
+        if 1 < g < x.n:
             logger.info(
                 "[*] Found common factor in modulus for "
                 + x.filename

--- a/attacks/multi_keys/commonfactors.py
+++ b/attacks/multi_keys/commonfactors.py
@@ -17,27 +17,25 @@ def attack(attack_rsa_obj, publickeys, cipher=[]):
 
     # Try to find the gcd between each pair of moduli and resolve the private keys if gcd > 1
     priv_keys = []
-    for x, y in itertools.combinations(publickeys, r=2):
-        if x.n != y.n:
-            g = gcd(x.n, y.n)
-            if g != 1:
-                logger.info(
-                    "[*] Found common factor in modulus for "
-                    + x.filename
-                    + " and "
-                    + y.filename
-                )
+    tmp = 1
+    for x in publickeys:
+        tmp *= x.n
+    for x in publickeys:
+        g = gcd(x.n, tmp)
+        if 1<g<n:
+            logger.info(
+                "[*] Found common factor in modulus for "
+                + x.filename
+                + " and "
+                + y.filename
+            )
 
-                # update each attackobj with a private_key
-                x.p = g
-                x.q = x.n // g
-                y.p = g
-                y.q = y.n // g
-                priv_key_1 = PrivateKey(int(x.p), int(x.q), int(x.e), int(x.n))
-                priv_key_2 = PrivateKey(int(y.p), int(y.q), int(y.e), int(y.n))
-                priv_keys.append(priv_key_1)
-                priv_keys.append(priv_key_2)
-
+            # update each attackobj with a private_key
+            x.p = g
+            x.q = x.n // g
+            priv_key = PrivateKey(int(x.p), int(x.q), int(x.e), int(x.n))
+            priv_keys.append(priv_key)
+            
     priv_keys = list(set(priv_keys))
     if len(priv_keys) == 0:
         priv_keys = None

--- a/attacks/multi_keys/commonfactors.py
+++ b/attacks/multi_keys/commonfactors.py
@@ -26,8 +26,6 @@ def attack(attack_rsa_obj, publickeys, cipher=[]):
             logger.info(
                 "[*] Found common factor in modulus for "
                 + x.filename
-                + " and "
-                + y.filename
             )
 
             # update each attackobj with a private_key


### PR DESCRIPTION
The trade-of is a little more memory for execution speed.
It can still be improved with batchgcd.