### PR TITLE
siqs: Fix location of yafu executable

### DIFF
--- a/attacks/single_key/siqs.py
+++ b/attacks/single_key/siqs.py
@@ -12,6 +12,7 @@
 #
 
 import os
+import pathlib
 import re
 import logging
 import subprocess
@@ -26,7 +27,7 @@ class SiqsAttack(object):
         """Configuration
         """
         self.logger = logging.getLogger("global_logger")
-        self.yafubin = "./yafu"  # where the binary is
+        self.yafubin = os.path.join(pathlib.Path(__file__).parent, "yafu")
         self.threads = 2  # number of threads
         self.maxtime = 180  # max time to try the sieve
 


### PR DESCRIPTION
The included yafu binary wasn't found.

Btw., your yafu segfaults on my Debian 10 (amd64) machine, so I had to rebuild it. I guess it would be better to look for yafu in $PATH and print a warning if it's not found, instead of including a prebuilt binary.

