### PR TITLE
Fixed missing imports and broken timeout

### DIFF
--- a/attacks/single_key/z3_solver.py
+++ b/attacks/single_key/z3_solver.py
@@ -1,30 +1,39 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 from z3 import *
-
 from gmpy2 import isqrt
+from lib.utils import timeout, TimeoutError
+from lib.keys_wrapper import PrivateKey
 
-def z3_solve(n):
-  p = Int('x')
-  q = Int('y')
-  s = Solver()
-  i = int(isqrt(n))
-  s.add(p*q == n, p > 1, q > i, q > p)
-  print(s.check())
-  res = s.model()
-  return res[p],res[q]
+def z3_solve(n, timeout_amount):
+    p = Int('x')
+    q = Int('y')
+    s = Solver()
+    i = int(isqrt(n))
+    s.add(p*q == n, p > 1, q > i, q > p)
+    s.set("timeout", timeout_amount * 1000)
+    try:
+        s_check_output = s.check()
+        print(check_output)
+        res = s.model()
+        return res[p],res[q]
+    except:
+        return None, None
 
 
 def attack(attack_rsa_obj, publickey, cipher=[]):
-    """Run attack with z3 method"""
+    timeout_amount = attack_rsa_obj.args.timeout
     if not hasattr(publickey, "p"):
         publickey.p = None
     if not hasattr(publickey, "q"):
         publickey.q = None
 
     # solve with z3 theorem prover
-    with timeout(attack_rsa_obj.args.timeout):
+    with timeout(timeout_amount):
         try:
             try:
-                euler_res = z3_solve(publickey.n)
+                euler_res = z3_solve(publickey.n, timeout_amount)
             except:
                 print("z3: Internal Error")
                 return (None, None)


### PR DESCRIPTION
Both Privatekey and Timeout were needed, but not imported causing import errors. Even after importing them, the s.check() function would cause the script to hang indefinitely. 