### PR TITLE
add cache for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,12 @@ jobs:
       fail-fast: false
 
     steps:
+    - name: Cache apt
+      id: cache-packages
+      uses: actions/cache@v2
+      with:
+        path: ${{ runner.temp }}/cache-linux
+        key: cache-packages-v2.2
     - uses: actions/checkout@v2
     - name: Setup python
       uses: actions/setup-python@v2


### PR DESCRIPTION
Simply cache the apt (pull, update) process to save time.