### PR TITLE
Add idrsa.pub disector and conversion to pem functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ usage: RsaCtfTool.py [-h] [--publickey PUBLICKEY] [--timeout TIMEOUT]
                      [--uncipherfile UNCIPHERFILE] [--uncipher UNCIPHER]
                      [--verbosity {CRITICAL,ERROR,WARNING,DEBUG,INFO}]
                      [--private] [--ecmdigits ECMDIGITS] [-n N] [-p P] [-q Q]
-                     [-e E] [--key KEY] [--isconspicuous]
+                     [-e E] [--key KEY] [--isconspicuous] [--convert_idrsa_pub]
                      [--attack {smallfraction,wiener,pastctfprimes,wolframalpha,factordb,fermat,ecm,primorial_pm1_gcd,binary_polinomial_factoring,fibonacci_gcd,londahl,smallq,mersenne_pm1_gcd,noveltyprimes,roca,pollard_p_1,boneh_durfee,ecm2,pollard_rho,z3_solver,cube_root,mersenne_primes,cm_factor,comfact_cn,fermat_numbers_gcd,qicheng,partial_q,siqs,euler,commonfactors,hastads,same_n_huge_e,all} [{smallfraction,wiener,pastctfprimes,wolframalpha,factordb,fermat,ecm,primorial_pm1_gcd,binary_polinomial_factoring,fibonacci_gcd,londahl,smallq,mersenne_pm1_gcd,noveltyprimes,roca,pollard_p_1,boneh_durfee,ecm2,pollard_rho,z3_solver,cube_root,mersenne_primes,cm_factor,comfact_cn,fermat_numbers_gcd,qicheng,partial_q,siqs,euler,commonfactors,hastads,same_n_huge_e,all} ...]]
 ```
 
@@ -108,6 +108,10 @@ Mode 3 : Dump the public and/or private numbers (optionally including CRT parame
 `./RsaCtfTool.py --publickey key.pub --ecmdigits 25 --verbose --private`
 
 For more examples, look at test.sh file
+
+### Convert idrsa.pub to pem format
+
+`./RsaCtfTool.py  --convert_idrsa_pub --publickey $HOME/.ssh/id_rsa.pub`
 
 ## Requirements
 

--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -28,6 +28,7 @@ from lib.keys_wrapper import (
     generate_keys_from_p_q_e_n,
     PrivateKey,
 )
+from lib.idrsa_pub_disector import disect_idrsa_pub
 
 # Remove insecure warning for factordb.com
 urllib3.disable_warnings(InsecureRequestWarning)
@@ -106,6 +107,10 @@ if __name__ == "__main__":
         "--isconspicuous", help="conspicuous key check", action="store_true"
     )
 
+    parser.add_argument(
+        "--convert_idrsa_pub", help="Convert idrsa.pub to pem", action="store_true"
+    )  
+
     args = parser.parse_args()
 
     unciphers = []
@@ -178,6 +183,17 @@ if __name__ == "__main__":
     # If we have n and one of p and q, calculated the other
     if args.n and (args.p or args.q):
         args.p, args.q = generate_pq_from_n_and_p_or_q(args.n, args.p, args.q)
+
+    # convert a idrsa.pub file to a pem format
+    if args.convert_idrsa_pub:
+        #for publickey in args.publickey:
+        publickey = args.publickey
+        logger.info("Converting %s: to pem..." % publickey)
+        with open(publickey, "rb") as key_data_fd:
+           n,e = disect_idrsa_pub(key_data_fd.read().decode('utf8'))
+           pub_key, priv_key = generate_keys_from_p_q_e_n(None, None, e, n)
+           print(pub_key.decode("utf-8"))
+        exit(0)
 
     # Create pubkey if requested
     if args.createpub:

--- a/lib/idrsa_pub_disector.py
+++ b/lib/idrsa_pub_disector.py
@@ -1,0 +1,44 @@
+# ssh id_rsa.pub field decoder
+import binascii
+import sys
+import os
+import time
+import base64
+
+def disect_idrsa_pub(pub):
+    a = pub.split(' ')
+    if a[0] == 'ssh-rsa':
+        bindata = base64.standard_b64decode(a[1])
+
+        def getdata(start,end):
+            field = bindata[start:end]
+            if len(field) > 0:
+                pos = int(binascii.hexlify(field),16)
+                data = bindata[end: end+pos]
+            else:
+                pos = len(bindata)
+                data = None
+            return pos,data
+        
+        if bindata:
+            start = 0
+            end = 4
+            pos = 0
+            c = []
+            data = ""
+
+            while pos < len(bindata):
+                pos,data = getdata(start,end)
+                if data != None:
+                    c.append(data)
+                start+=pos+4
+                end=start+4
+
+            E = int(binascii.hexlify(c[1]),16)
+            N = int(binascii.hexlify(c[2]),16)
+            return (N,E)
+        else:
+            return None
+    else:
+        return None
+


### PR DESCRIPTION
This PR adds the posibility to convert idrsa.pub from ssh to pem format for later attacking.

./RsaCtfTool.py  --convert_idrsa_pub --publickey $HOME/.ssh/id_rsa.pub
private argument is not set, the private key will not be displayed, even if recovered.
Converting /home/dclavijo/.ssh/id_rsa.pub: to pem...
-----BEGIN PUBLIC KEY-----
MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0svoPrlEHIVaEVfrXVr5
REDACTED
gWpNzo4/8My0xnZgJ4wrm8EzgkGGhJaQAEioFGBFz7C52qV/dgDj2UA6NWU4fntn
nQIDAQAB
-----END PUBLIC KEY-----