### PR TITLE
Remove erroneous get_base64_value() call in line 185, which writes over uncipher with a list object

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -182,7 +182,6 @@ if __name__ == "__main__":
         uncipher_array = []
         for uncipher in args.uncipher.split(","):
             uncipher = get_numeric_value(uncipher)
-            uncipher = get_base64_value(unciphers)
             uncipher_array.append(n2s(uncipher))
         args.uncipher = uncipher_array
 


### PR DESCRIPTION
This modification resolves one of the open issues listed where 'list' object cannot be interpreted as an integer.

Note: this is my first time contributing to a git project; please review before committing to ensure correct implementation.