### PR TITLE
Fixed multiple run-time exceptions caused by normal command line parameter combinations and normal keys

### DIFF
--- a/RsaCtfTool.py
+++ b/RsaCtfTool.py
@@ -367,12 +367,16 @@ if __name__ == "__main__":
             attackobj.attack_single_key(tmpfile.name, attacks_list, test=True)
 
     # Attack multiple keys
-    if len(args.publickey) > 1:
+    if args.publickey is not None and len(args.publickey) > 1:
         found = attackobj.attack_multiple_keys(args.publickey, attacks_list)
 
     # Attack key
-    for publickey in args.publickey:
-        attackobj.implemented_attacks = []
-        logger.info("\n[*] Testing key %s." % publickey)
-        attackobj.attack_single_key(publickey, attacks_list)
-        attackobj.unciphered = []
+    if args.publickey is not None:
+        for publickey in args.publickey:
+            attackobj.implemented_attacks = []
+            logger.info("\n[*] Testing key %s." % publickey)
+            attackobj.attack_single_key(publickey, attacks_list)
+            attackobj.unciphered = []
+
+    if args.publickey is None:
+        logger.error("No key specified")

--- a/attacks/single_key/cube_root.py
+++ b/attacks/single_key/cube_root.py
@@ -16,6 +16,9 @@ class Attack(AbstractAttack):
             try:
                 if publickey.e == 3 or publickey.e == 5:
                     plain = []
+                    if (cipher is None) or (len(cipher) < 1):
+                        self.logger.info("[-] No ciphertexts specified, skiping the cube_root test...")
+                        return (None, None)
                     for c in cipher:
                         cipher_int = int.from_bytes(c, "big")
                         low = 0

--- a/attacks/single_key/pollard_p_1.py
+++ b/attacks/single_key/pollard_p_1.py
@@ -16,7 +16,7 @@ class Attack(AbstractAttack):
     def pollard_P_1(self, n, progress=True):
         """Pollard P1 implementation"""
         z = []
-        
+
         def first_primes(n):
            p = 2
            tmp = [p]
@@ -24,13 +24,15 @@ class Attack(AbstractAttack):
              p = next_prime(p)
              tmp.append(p)
            return tmp
-        
-        prime = first_primes(997)
 
-        B1 = isqrt(n)
+        prime = first_primes(997)
+        logn=math.log(int(isqrt(n)))
+
         for j in range(0, len(prime)):
-            for i in range(1, int(math.log(B1) / math.log(prime[j])) + 1):
-                z.append(prime[j])
+             primej = prime[j]
+             logp = math.log(primej)
+             for i in range(1, int(logn / logp) + 1):
+                z.append(primej)
 
         try:
             for pp in tqdm(prime, disable=(not progress)):


### PR DESCRIPTION

    1. Fixed an exception error on the cube test when the program was run with the parameters "-n" and "-e 3" and no ciphertexts were specified.
    2. Fixed an exception when the program was run with "--sendtofdb" and with at least 3 public keys: at least 2 had common factors and at least 1 did not have.
    3. Fixed a conversion error/overflow from float to integer.
    4. Fixed an exception when the program was run with ciphertexts but without public keys.

