### PR TITLE
RsaCtfTool tries to access ciphertexts when they are not needed. This causes TypeError: 'NoneType' object is not iterable

### DIFF
--- a/attacks/single_key/ecm2.py
+++ b/attacks/single_key/ecm2.py
@@ -37,14 +37,15 @@ class Attack(AbstractAttack):
                 for fac in sageresults:
                     phi = phi * (int(fac) - 1)
 
-                for c in cipher:
-                    try:
-                        cipher_int = int.from_bytes(c, "big")
-                        d = modInv(publickey.e, phi)
-                        m = hex(pow(cipher_int, d, publickey.n))[2::]
-                        plain.append(bytes.fromhex(m))
-                    except:
-                        continue
+                if cipher is not None and len(cipher) > 0:
+                    for c in cipher:
+                        try:
+                            cipher_int = int.from_bytes(c, "big")
+                            d = modInv(publickey.e, phi)
+                            m = hex(pow(cipher_int, d, publickey.n))[2::]
+                            plain.append(bytes.fromhex(m))
+                        except:
+                            continue
 
                 return (None, plain)
             return (None, None)

--- a/attacks/single_key/factordb.py
+++ b/attacks/single_key/factordb.py
@@ -97,10 +97,11 @@ class Attack(AbstractAttack):
                         phi *= int(p) - 1
                     d = invmod(publickey.e, phi)
                     plains = []
-                    for c in cipher:
-                        int_big = int.from_bytes(c, "big")
-                        plain1 = pow(int_big, d, publickey.n)
-                        plains.append(long_to_bytes(plain1))
+                    if cipher is not None and len(cipher) > 0:
+                        for c in cipher:
+                            int_big = int.from_bytes(c, "big")
+                            plain1 = pow(int_big, d, publickey.n)
+                            plains.append(long_to_bytes(plain1))
                     return (None, plains)
                 return (None, None)
             except NotImplementedError:

--- a/test.sh
+++ b/test.sh
@@ -64,3 +64,5 @@ echo -e "\033[1m\nTest fibonacci gcd\033[0m"
 time ./RsaCtfTool.py --publickey examples/fibonacci_gcd.pub --attack fibonacci_gcd --private
 echo -e "\033[1m\nTest small crt exponent\033[0m"
 time ./RsaCtfTool.py --publickey examples/small_crt_exp.pub --attack small_crt_exp --private
+echo -e "\033[1m\nTest to make sure that it does not fail when the list of ciphertexts does not exist\033[0m"
+time ./RsaCtfTool.py -n 90377629292003121684002147101760858109247336549001090677693 -e 65537 --sendtofdb --private --timeout 100 --attack factordb


### PR DESCRIPTION
```
./RsaCtfTool.py -n 90377629292003121684002147101760858109247336549001090677693 -e 65537 --sendtofdb --private --timeout 100 --attack factordb

[*] Testing key /tmp/tmp3qv1so48.
[*] Performing factordb attack on /tmp/tmp3qv1so48.
Traceback (most recent call last):
  File "./RsaCtfTool.py", line 378, in <module>
    attackobj.attack_single_key(publickey, attacks_list)
  File "/home/max/src/original-github-repo/RsaCtfTool/lib/rsa_attack.py", line 285, in attack_single_key
    self.priv_key, unciphered = attack_module.attack(
  File "/home/max/src/original-github-repo/RsaCtfTool/attacks/single_key/factordb.py", line 100, in attack
    for c in cipher:
TypeError: 'NoneType' object is not iterable
```