### PR TITLE
Upgrade primality test on non gmpy systems, add fermats prime criterion

### DIFF
--- a/lib/rsalibnum.py
+++ b/lib/rsalibnum.py
@@ -138,14 +138,20 @@ def miller_rabin(n, k=40):
     return True
 
 
-def _fermat_prime_criterion(n):
+def _fermat_prime_criterion(n,b=2):
   """Fermat's prime criterion
   Returns False if n is definitely composite, True if posible prime."""
-  return pow(2,n-1,n) == 1
+  return pow(b,n-1,n) == 1
 
 
 def _is_prime(n):
-  if _fermat_prime_criterion(n):
+  """
+  If fermats prime criterion is false by short circuit we dont need to keep testing bases, so we return false for a guaranteed composite.
+  Otherwise we keep trying with primes 3 and 5 as base. The sweet spot is primes 2,3,5, it doesn't improvee the runing time adding more primes to test as base.
+  If all the previus tests pass then we try with rabin miller.
+  All the tests are probabilistic.
+  """
+  if _fermat_prime_criterion(n) and _fermat_prime_criterion(n,b=3) and _fermat_prime_criterion(n,b=5):
     return miller_rabin(n)
   else:
     return False

--- a/lib/rsalibnum.py
+++ b/lib/rsalibnum.py
@@ -120,9 +120,9 @@ def miller_rabin(n, k=40):
     r, s = 0, n - 1
     while s & 1 == 0:
         r += 1
-        s //= 2
+        s >>= 1
     i = 0
-    while i <= k:
+    for i in range(0,k):
         a = random.randrange(2, n - 1)
         x = pow(a, s, n)
         if x == 1 or x == n - 1:
@@ -135,9 +135,21 @@ def miller_rabin(n, k=40):
             j += 1
         else:
             return False
-        i += 1
     return True
-_is_prime = miller_rabin
+
+
+def _fermat_prime_criterion(n):
+  """Fermat's prime criterion
+  Returns False if n is definitely composite, True if posible prime."""
+  return pow(2,n-1,n) == 1
+
+
+def _is_prime(n):
+  if _fermat_prime_criterion(n):
+    return miller_rabin(n)
+  else:
+    return False
+
 
 def _next_prime(n):
     while True:


### PR DESCRIPTION
if pow(2,n-1,n) == 1  then n is probable prime and then 
  we test it with miller_rabin 
else 
  return false because is definitly composite.

We save a lot of time by not running miller_rabin on every number.

The tests I ran are here: https://github.com/daedalus/isprimetimings, 8.07X runtime improvement over miller_rabin alone.