### PR TITLE
requirements.txt: Upgrade insecure pycryptodome

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ urllib3==1.26.5
 requests==2.25.1
 gmpy==1.17
 gmpy2==2.1.0b5
-pycryptodome==3.9.7
+pycryptodome==3.10.4
 tqdm
 z3-solver
 pycrypto


### PR DESCRIPTION
https://pypi.org/project/pycryptodome/

$ [`safety check`](https://pypi.org/project/safety)
```
+==============================================================================+
|                                                                              |
|                               /$$$$$$            /$$                         |
|                              /$$__  $$          | $$                         |
|           /$$$$$$$  /$$$$$$ | $$  \__//$$$$$$  /$$$$$$   /$$   /$$           |
|          /$$_____/ |____  $$| $$$$   /$$__  $$|_  $$_/  | $$  | $$           |
|         |  $$$$$$   /$$$$$$$| $$_/  | $$$$$$$$  | $$    | $$  | $$           |
|          \____  $$ /$$__  $$| $$    | $$_____/  | $$ /$$| $$  | $$           |
|          /$$$$$$$/|  $$$$$$$| $$    |  $$$$$$$  |  $$$$/|  $$$$$$$           |
|         |_______/  \_______/|__/     \_______/   \___/   \____  $$           |
|                                                          /$$  | $$           |
|                                                         |  $$$$$$/           |
|  by pyup.io                                              \______/            |
|                                                                              |
+==============================================================================+
| REPORT                                                                       |
| checked 57 packages, using free DB (updated once a month)                    |
+============================+===========+==========================+==========+
| package                    | installed | affected                 | ID       |
+============================+===========+==========================+==========+
| pycryptodome               | 3.9.7     | <3.10.3                  | 41775    |
| pycrypto                   | 2.6.1     | <=2.6.1                  | 35015    |
+==============================================================================+
```