### PR TITLE
Improve the decryption when p equals q

### DIFF
--- a/lib/keys_wrapper.py
+++ b/lib/keys_wrapper.py
@@ -114,7 +114,11 @@ class PrivateKey(object):
 
         self.key = None
         if self.p is not None and self.q is not None and self.d is not None:
-            self.key = RSA.construct((self.n, self.e, self.d, self.p, self.q))
+            try:
+                # There is no CRT coefficient to construct a key if p equals q
+                self.key = RSA.construct((self.n, self.e, self.d, self.p, self.q))
+            except ValueError:
+                pass
         elif n is not None and e is not None and d is not None:
             try:
                 self.key = RSA.construct((self.n, self.e, self.d))
@@ -161,11 +165,11 @@ class PrivateKey(object):
 
         plain = []
         for c in cipher:
-            if self.n is not None and self.d is not None and self.key is None:
+            if self.n is not None and self.d is not None:
                 try:
                     cipher_int = int.from_bytes(c, "big")
                     m_int = powmod(cipher_int, self.d, self.n)
-                    m = binascii.unhexlify(hex(m_int)[2:]).decode()
+                    m = binascii.unhexlify(hex(m_int)[2:])
                     plain.append(m)
                 except:
                     pass


### PR DESCRIPTION
If p equals q, there is no CRT coefficient to construct a key. However, the decryption can still be done.