### PR TITLE
Remove pycrypto dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,5 @@ gmpy2==2.1.0b5
 pycryptodome==3.10.4
 tqdm
 z3-solver
-pycrypto
 bitarray
 egcd


### PR DESCRIPTION
Related to: https://github.com/Ganapati/RsaCtfTool/issues/289

According to https://www.pycrypto.org/ pycrypto is no longer
maintaned and pycryptodome is a drop-in replacement. (This has
largely been recognized as such for the past few years).