### PR TITLE
Add non RSA key attack (n = b^x with b prime)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Attacks :
 - Fermat's factorisation for close p and q
 - Gimmicky Primes method
 - Past CTF Primes method
+- Non RSA key in the form b^x, where b is prime
 - Self-Initializing Quadratic Sieve (SIQS) using Yafu (<https://github.com/DarkenCode/yafu.git>)
 - Common factor attacks across multiple keys
 - Small fractions method when p/q is close to a small fraction

--- a/attacks/single_key/nonRSA.py
+++ b/attacks/single_key/nonRSA.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+from cmath import pi
+from attacks.abstract_attack import AbstractAttack
+from lib.keys_wrapper import PrivateKey
+from lib.rsalibnum import is_prime, invmod, ilog2, introot
+
+
+class Attack(AbstractAttack):
+    def __init__(self, timeout=60):
+        super().__init__(timeout)
+        self.speed = AbstractAttack.speed_enum["fast"]
+
+    def attack(self, publickey, cipher=[], progress=True):
+        """try to factorize n when is in the form: root^x, with root prime"""
+        n = publickey.n
+        e = publickey.e
+
+        if is_prime(n):
+            phi = n - 1
+            d = invmod(e, phi)
+            priv_key = PrivateKey(
+                n=n,
+                e=e,
+                d=d   
+            )
+            return (priv_key, None)
+
+        for i in range(2, ilog2(n) + 1)[::-1]:  # we need to find the largest power first, otherwise, it would never be prime
+            root = introot(n, i)
+            if pow(root, i) == n:
+                self.logger.info("n = %d^%d" % (root, i))
+                if not is_prime(root):
+                    self.logger.warning("[!] n = base^x, but base is not prime")
+                    return (None, None)
+                else:
+                    phi = (root - 1) * pow(root, i - 1)
+                    d = invmod(e, phi)
+                    self.logger.info("d = %d" % d)
+                    self.logger.warning("[!] Since this is not a valid RSA key, attempts to display the private key will fail")
+                    priv_key = PrivateKey(
+                        n=n,
+                        e=e,
+                        d=d   
+                    )
+                    return (priv_key, None)
+
+        return (None, None)
+
+    def test(self):
+        from lib.keys_wrapper import PublicKey
+        key_data = """-----BEGIN PUBLIC KEY-----
+MIIBIzANBgkqhkiG9w0BAQEFAAOCARAAMIIBCwKCAQILdjaT+X2D8Er2cSNPoG6k
+oFBngdQrBrtcAwykNQ9hxbZzX2ZCImBZ7apKUsbJuuK1+1+jcaYJMMkGE9FeVgo/
+7xu8KTvRX6Y5Y+RbQUzpqux64BBA9chkkOYoI2nZse0L/LrvqJBDAfeGRNS3MAOc
+ipiPqnu3KcRgO+e2f/Nl8m7YqjQJsrMiRlUf8WstNVAn598EBgqw8oDt0pATVRSR
+7Zc7xKbuehqOQNw2We3SJrP06+/IM7TQ9hTRv4v9u5lAa923neE4WXDa1HXEspeN
+bSZ+A/Iw4Vt09AY9zPRqUzxfn7t9kTqsL9+/R8bdREA2byem8SWhCXvWJexmanUr
+ZcECAwEAAQ==
+-----END PUBLIC KEY-----"""
+        e = 0x10001
+        result = self.attack(PublicKey(key_data), progress=False)
+        return result != (None, None)

--- a/lib/rsa_attack.py
+++ b/lib/rsa_attack.py
@@ -318,6 +318,8 @@ class RSAAttack(object):
                 self.logger.warning("Timeout")
             except NotImplementedError:
                 self.logger.warning("[!] This attack module is not implemented yet")
+            except KeyboardInterrupt:
+                self.logger.warning("[!] Interrupted")
 
         self.print_results_details(publickey)
         self.priv_key_send2fdb()


### PR DESCRIPTION
I created an attack module to break non RSA keys in the form b^x, with b prime (but also warns if it is not prime).
This should close issues #313 and #286.
I also added an exception handler for KeyboardInterrupt in the principal try catch, so that you can stop an attack if you already know that it won't work, without stopping the whole tool.